### PR TITLE
Catch exception when author is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,14 +90,18 @@ async function isOnTeam(client, author, teams) {
         //console.log(author);
         //console.log(github.context.payload);
         //console.log(github.context.payload.organization.name);
-        const response = await client.teams.getMembershipForUserInOrg({
-            org: github.context.payload.organization.login,
-            team_slug: team,
-            username: author,
-        });
-        //console.log(response);
-        if (response.status == 200 && response.data.state != "pending") {
-            return true;
+        try {
+            const response = await client.teams.getMembershipForUserInOrg({
+                org: github.context.payload.organization.login,
+                team_slug: team,
+                username: author,
+            });
+            //console.log(response);
+            if (response.status == 200 && response.data.state != "pending") {
+                return true;
+            }
+        } catch (error) {
+            console.log('Error when checking memebership for author ', author, ' in team ', team, '. Message: ', error.message);
         }
     }
     return false

--- a/index.js
+++ b/index.js
@@ -37,15 +37,17 @@ async function fetchContent(client, repoPath) {
 }
 
 async function assignReviewers(client, { individuals, teams }) {
-    await client.pulls.requestReviewers({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        pull_number: github.context.payload.pull_request.number,
-        reviewers: individuals,
-        team_reviewers: teams,
-    });
-    core.info(`Assigned individual reviews to ${individuals}.`);
-    core.info(`Assigned team reviews to ${teams}.`);
+    if (individuals.length || teams.length) {
+        await client.pulls.requestReviewers({
+            owner: github.context.repo.owner,
+            repo: github.context.repo.repo,
+            pull_number: github.context.payload.pull_request.number,
+            reviewers: individuals,
+            team_reviewers: teams,
+        });
+        core.info(`Assigned individual reviews to ${individuals}.`);
+        core.info(`Assigned team reviews to ${teams}.`);
+    }
 }
 
 async function getDesiredReviewAssignments(client, config) {


### PR DESCRIPTION
In BriteCore repo, when a PR is created, if the author is not in the configured team the check is failing:
![image](https://user-images.githubusercontent.com/1126536/98425092-af0a9900-2072-11eb-9f75-3fe4d235adbb.png)

We need to catch the "Not Found" error to continue checking other rules or if not finish the action without assigned reviewers.