### PR TITLE
properly map action inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,7 @@ description: Assign reviews to individuals or teams based on the pr's author or 
 branding:
   icon: user-check
   color: purple
+inputs:
   GITHUB_TOKEN:
     description: "Github token"
     required: true


### PR DESCRIPTION
### Inputs are not mapped correctly in the `action.yml` definition.
![Screen Shot 2020-12-21 at 5 22 00 PM](https://user-images.githubusercontent.com/13183831/102834555-9a2f5e00-43b1-11eb-8ff5-c16dda0bee4e.png)


### This adds the `inputs` key for both the `GITHUB_TOKEN` and `config` inputs.