### PR TITLE
Allow setting ignored teams and 'any' author

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,28 @@ when:
         - Author1
         - Author2
 
+  # Any PR which is from a specific author.
   - author: 
       nameIs: 
-        - acq688
+        - myles2007
     assign:
       individuals:
-        - myles2007
+        - acq688
+
+  # Any PR which is from a specific team.
   - author: 
       teamIs: 
+        - solution-architecture
+    assign:
+      individuals:
+        - acq688
+
+  # Any PR which is not from a specific team.
+  - author:
+      nameIs:
+        - any
+    ignore:
+      teamIs:
         - solution-architecture
     assign:
       individuals:

--- a/index.js
+++ b/index.js
@@ -63,14 +63,22 @@ async function getDesiredReviewAssignments(client, config) {
         const authorSet = condition.author.nameIs || [];
         const authorIgnoreSet = condition.author.ignore.nameIs || [];
         const teamSet = condition.author.teamIs || [];
+        const teamIgnoreSet = condition.author.ignore.teamIs || [];
         const individualAssignments = condition.assign.individuals || [];
         const teamAssignments = condition.assign.teams || [];
 
-        if (authorIgnoreSet.includes(author)) {
+        const authorIsIgnored = authorIgnoreSet.includes(author);
+        const authorIsInIgnoredTeam = await isOnTeam(
+          client,
+          author,
+          teamIgnoreSet
+        );
+        if (authorIsIgnored || authorIsInIgnoredTeam) {
             continue;
         }
 
-        const isAuthorOfInterest = authorSet.includes(author);
+        const isAuthorOfInterest =
+          authorSet.includes(author) || authorSet.includes('any');
         const isOnTeamOfInterest = await isOnTeam(client, author, teamSet);
 
         //console.log(individualAssignments);


### PR DESCRIPTION
We are facing a case where we would like to auto-assign external contributor PRs (https://github.com/woocommerce/woocommerce-blocks/issues/5961). In other words, we would need something along these lines:

```md
- author:
    nameIs:
      - any
  ignore:
    teamIs:
      - solution-architecture
  assign:
    individuals:
      - acq688
```

So, it selects all PRs from any author, ignoring PRs from team `solution-architecture` and assigns them to `acq688`.

If I'm not wrong, that's not currently possible with this action. Because of that, this PR:

* Introduces the `ignore: teamIs:` rule, similar to `ignore: nameIs:`, so it's possible to ignore entire teams.
* Introduces the `any` key for the `nameIs` rule, so we can select all PRs.

I updated the docs accordingly to make it easier to understand what's possible with this action.

Please let me know if the API doesn't look good or if the code needs to be changed. Thanks in advance!